### PR TITLE
Use different equality tester of scales

### DIFF
--- a/tests/testthat/test-attackontitan.R
+++ b/tests/testthat/test-attackontitan.R
@@ -1,6 +1,12 @@
 context("test-attackontitan")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 ## Attack on Titan
 test_that("attackOnTitan_pal raises warning with large number, x > 8", {
@@ -10,7 +16,7 @@ test_that("attackOnTitan_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_attackOnTitan equals scale_color_attackOnTitan", {
-  expect_eqNe(scale_color_attackOnTitan(), scale_colour_attackOnTitan())
+  expect_equal_scales(scale_color_attackOnTitan(), scale_colour_attackOnTitan())
 })
 
 test_that("scale_colour_attackOnTitan works", {

--- a/tests/testthat/test-bighero6.R
+++ b/tests/testthat/test-bighero6.R
@@ -1,6 +1,12 @@
 context("test-bighero6")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment=FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 ## Big Hero 6
 test_that("bigHero6_pal raises warning with large number, x > 8", {
@@ -10,12 +16,7 @@ test_that("bigHero6_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_bigHero6 equals scale_color_bigHero6", {
-  expect_eqNe(scale_color_bigHero6(), scale_colour_bigHero6())
-})
-
-test_that("scale_color_bigHero6 name is correct", {
-  color_scale <- scale_color_bigHero6()
-  expect_equal(color_scale$scale_name, "bigHero6")
+  expect_equal_scales(scale_color_bigHero6(), scale_colour_bigHero6())
 })
 
 test_that("scale_colour_bigHero6 works", {

--- a/tests/testthat/test-brooklyn99.R
+++ b/tests/testthat/test-brooklyn99.R
@@ -1,6 +1,12 @@
 context("test-brooklyn99")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment=FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 test_that("theme_brooklyn99 works", {
   thm <- theme_brooklyn99()
@@ -64,8 +70,8 @@ test_that("brooklyn99_pal raises warning with large number, x > 10", {
 })
 
 test_that("scale_colour_brooklyn99/dark equals scale_color_brooklyn99/dark", {
-  expect_eqNe(scale_color_brooklyn99(palette = "Regular"), scale_colour_brooklyn99(palette = "Regular"))
-  expect_eqNe(scale_color_brooklyn99(palette = "Dark"), scale_colour_brooklyn99(palette = "Dark"))
+  expect_equal_scales(scale_color_brooklyn99(palette = "Regular"), scale_colour_brooklyn99(palette = "Regular"))
+  expect_equal_scales(scale_color_brooklyn99(palette = "Dark"), scale_colour_brooklyn99(palette = "Dark"))
 })
 
 test_that("scale_colour_brooklyn99/dark works", {

--- a/tests/testthat/test-gameofthrones.R
+++ b/tests/testthat/test-gameofthrones.R
@@ -1,6 +1,12 @@
 context("test-gameofthrones")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 ## House Stark ----
 test_that("stark_pal raises warning with large number, x > 9", {
@@ -10,7 +16,7 @@ test_that("stark_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_stark equals scale_color_stark", {
-  expect_eqNe(scale_color_westeros(palette = "Stark"), scale_colour_westeros(palette = "Stark"))
+  expect_equal_scales(scale_color_westeros(palette = "Stark"), scale_colour_westeros(palette = "Stark"))
 })
 
 test_that("scale_colour_stark works", {
@@ -27,7 +33,7 @@ test_that("Lannister_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Lannister equals scale_color_Lannister", {
-  expect_eqNe(scale_color_westeros(palette = "Lannister"), scale_colour_westeros(palette = "Lannister"))
+  expect_equal_scales(scale_color_westeros(palette = "Lannister"), scale_colour_westeros(palette = "Lannister"))
 })
 
 test_that("scale_colour_Lannister works", {
@@ -44,7 +50,7 @@ test_that("Tyrell_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Tyrell equals scale_color_Tyrell", {
-  expect_eqNe(scale_color_westeros(palette = "Tyrell"), scale_colour_westeros(palette = "Tyrell"))
+  expect_equal_scales(scale_color_westeros(palette = "Tyrell"), scale_colour_westeros(palette = "Tyrell"))
 })
 
 test_that("scale_colour_Tyrell works", {
@@ -61,7 +67,7 @@ test_that("Targaryen_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Targaryen equals scale_color_Targaryen", {
-  expect_eqNe(scale_color_westeros(palette = "Targaryen"), scale_colour_westeros(palette = "Targaryen"))
+  expect_equal_scales(scale_color_westeros(palette = "Targaryen"), scale_colour_westeros(palette = "Targaryen"))
 })
 
 test_that("scale_colour_Targaryen works", {
@@ -78,7 +84,7 @@ test_that("Tully_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Tully equals scale_color_Tully", {
-  expect_eqNe(scale_color_westeros(palette = "Tully"), scale_colour_westeros(palette = "Tully"))
+  expect_equal_scales(scale_color_westeros(palette = "Tully"), scale_colour_westeros(palette = "Tully"))
 })
 
 test_that("scale_colour_Tully works", {
@@ -95,7 +101,7 @@ test_that("Greyjoy_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Greyjoy equals scale_color_Greyjoy", {
-  expect_eqNe(scale_color_westeros(palette = "Greyjoy"), scale_colour_westeros(palette = "Greyjoy"))
+  expect_equal_scales(scale_color_westeros(palette = "Greyjoy"), scale_colour_westeros(palette = "Greyjoy"))
 })
 
 test_that("scale_colour_Greyjoy works", {
@@ -112,7 +118,7 @@ test_that("Manderly_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Manderly equals scale_color_Manderly", {
-  expect_eqNe(scale_color_westeros(palette = "Manderly"), scale_colour_westeros(palette = "Manderly"))
+  expect_equal_scales(scale_color_westeros(palette = "Manderly"), scale_colour_westeros(palette = "Manderly"))
 })
 
 test_that("scale_colour_Manderly works", {
@@ -129,7 +135,7 @@ test_that("Stannis_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Stannis equals scale_color_Stannis", {
-  expect_eqNe(scale_color_westeros(palette = "Stannis"), scale_colour_westeros(palette = "Stannis"))
+  expect_equal_scales(scale_color_westeros(palette = "Stannis"), scale_colour_westeros(palette = "Stannis"))
 })
 
 test_that("scale_colour_Stannis works", {
@@ -146,7 +152,7 @@ test_that("Martell_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Martell equals scale_color_Martell", {
-  expect_eqNe(scale_color_westeros(palette = "Martell"), scale_colour_westeros(palette = "Martell"))
+  expect_equal_scales(scale_color_westeros(palette = "Martell"), scale_colour_westeros(palette = "Martell"))
 })
 
 test_that("scale_colour_Martell works", {
@@ -163,7 +169,7 @@ test_that("Arryn_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_Arryn equals scale_color_Arryn", {
-  expect_eqNe(scale_color_westeros(palette = "Arryn"), scale_colour_westeros(palette = "Arryn"))
+  expect_equal_scales(scale_color_westeros(palette = "Arryn"), scale_colour_westeros(palette = "Arryn"))
 })
 
 test_that("scale_colour_Arryn works", {

--- a/tests/testthat/test-gravityfalls.R
+++ b/tests/testthat/test-gravityfalls.R
@@ -1,6 +1,12 @@
 context("test-gravityFalls")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 ## Big Hero 6
 test_that("gravityFalls_pal raises warning with large number, x > 15", {
@@ -10,12 +16,7 @@ test_that("gravityFalls_pal raises warning with large number, x > 15", {
 })
 
 test_that("scale_colour_gravityFalls equals scale_color_gravityFalls", {
-  expect_eqNe(scale_color_gravityFalls(), scale_colour_gravityFalls())
-})
-
-test_that("scale_color_gravityFalls name is correct", {
-  color_scale <- scale_color_gravityFalls()
-  expect_equal(color_scale$scale_name, "gravityFalls")
+  expect_equal_scales(scale_color_gravityFalls(), scale_colour_gravityFalls())
 })
 
 test_that("scale_colour_gravityFalls works", {

--- a/tests/testthat/test-hilda.R
+++ b/tests/testthat/test-hilda.R
@@ -1,6 +1,12 @@
 context("test-hilda")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 # Hilda Day ----
 test_that("theme_hildaDay works", {
@@ -66,7 +72,7 @@ test_that("hilda_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_hilda equals scale_color_hilda", {
-  expect_eqNe(scale_color_hilda(palette = "Day"), scale_colour_hilda(palette = "Day"))
+  expect_equal_scales(scale_color_hilda(palette = "Day"), scale_colour_hilda(palette = "Day"))
 })
 
 test_that("scale_colour_hilda works", {
@@ -139,7 +145,7 @@ test_that("hilda_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_hilda equals scale_color_hilda", {
-  expect_eqNe(scale_color_hilda(palette = "Dusk"), scale_colour_hilda(palette = "Dusk"))
+  expect_equal_scales(scale_color_hilda(palette = "Dusk"), scale_colour_hilda(palette = "Dusk"))
 })
 
 test_that("scale_colour_hilda works", {
@@ -212,7 +218,7 @@ test_that("hilda_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_hilda equals scale_color_hilda", {
-  expect_eqNe(scale_color_hilda(palette = "Night"), scale_colour_hilda(palette = "Night"))
+  expect_equal_scales(scale_color_hilda(palette = "Night"), scale_colour_hilda(palette = "Night"))
 })
 
 test_that("scale_colour_hilda works", {

--- a/tests/testthat/test-kimpossible.R
+++ b/tests/testthat/test-kimpossible.R
@@ -1,6 +1,12 @@
 context("test-kimpossible")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 ## Kim Possible
 test_that("kimPossible_pal raises warning with large number, x > 12", {
@@ -10,12 +16,7 @@ test_that("kimPossible_pal raises warning with large number, x > 12", {
 })
 
 test_that("scale_colour_kimPossible equals scale_color_kimPossible", {
-  expect_eqNe(scale_color_kimPossible(), scale_colour_kimPossible())
-})
-
-test_that("scale_color_kimPossible name is correct", {
-  color_scale <- scale_color_kimPossible()
-  expect_equal(color_scale$scale_name, "kimPossible")
+  expect_equal_scales(scale_color_kimPossible(), scale_colour_kimPossible())
 })
 
 test_that("scale_colour_kimPossible works", {

--- a/tests/testthat/test-parksandrec.R
+++ b/tests/testthat/test-parksandrec.R
@@ -1,6 +1,13 @@
 context("test-parksandrec")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
+
 
 test_that("theme_parksAndRec works", {
   thm <- theme_parksAndRec()
@@ -176,7 +183,7 @@ test_that("parksAndRec_pal raises warning with large number, x > 10", {
 })
 
 test_that("scale_colour_parksAndRec equals scale_color_parksAndRec", {
-  expect_eqNe(scale_color_parksAndRec(), scale_colour_parksAndRec())
+  expect_equal_scales(scale_color_parksAndRec(), scale_colour_parksAndRec())
 })
 
 test_that("scale_colour_parksAndRec/light works", {

--- a/tests/testthat/test-rickandmorty.R
+++ b/tests/testthat/test-rickandmorty.R
@@ -1,6 +1,12 @@
 context("test-rickandmorty")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 test_that("theme_rickAndMorty works", {
   thm <- theme_rickAndMorty()
@@ -64,7 +70,7 @@ test_that("rickAndMorty_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_rickAndMorty equals scale_color_rickAndMorty", {
-  expect_eqNe(scale_color_rickAndMorty(), scale_colour_rickAndMorty())
+  expect_equal_scales(scale_color_rickAndMorty(), scale_colour_rickAndMorty())
 })
 
 test_that("scale_colour_rickAndMorty works", {

--- a/tests/testthat/test-simpsons.R
+++ b/tests/testthat/test-simpsons.R
@@ -1,6 +1,12 @@
 context("test-simpsons")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 test_that("theme_simpsons works", {
   thm <- theme_simpsons()
@@ -64,7 +70,7 @@ test_that("simpsons_pal raises warning with large number, x > 10", {
 })
 
 test_that("scale_colour_simpsons equals scale_color_simpsons", {
-  expect_eqNe(scale_color_simpsons(), scale_colour_simpsons())
+  expect_equal_scales(scale_color_simpsons(), scale_colour_simpsons())
 })
 
 test_that("scale_colour_simpsons works", {

--- a/tests/testthat/test-spongebob.R
+++ b/tests/testthat/test-spongebob.R
@@ -1,6 +1,12 @@
 context("test-spongebob")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment = FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 test_that("theme_spongeBob works", {
   thm <- theme_spongeBob()
@@ -64,7 +70,7 @@ test_that("spongeBob_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_spongeBob equals scale_color_spongeBob", {
-  expect_eqNe(scale_color_spongeBob(), scale_colour_spongeBob())
+  expect_equal_scales(scale_color_spongeBob(), scale_colour_spongeBob())
 })
 
 test_that("scale_colour_spongeBob works", {

--- a/tests/testthat/test-stevenuniverse.R
+++ b/tests/testthat/test-stevenuniverse.R
@@ -1,3 +1,10 @@
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
+
 ### Steven ----
 
 test_that('Steven_pal raises warning with large number, x > 8', {
@@ -7,7 +14,7 @@ test_that('Steven_pal raises warning with large number, x > 8', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Steven', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Steven'), scale_colour_stevenUniverse(palette = 'Steven'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Steven'), scale_colour_stevenUniverse(palette = 'Steven'))
 })
 
 test_that('scale_colour_Steven works', {
@@ -27,7 +34,7 @@ test_that('Garnet_pal raises warning with large number, x > 9', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Garnet', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Garnet'), scale_colour_stevenUniverse(palette = 'Garnet'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Garnet'), scale_colour_stevenUniverse(palette = 'Garnet'))
 })
 
 test_that('scale_colour_Garnet works', {
@@ -47,7 +54,7 @@ test_that('Amethyst_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Amethyst', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Amethyst'), scale_colour_stevenUniverse(palette = 'Amethyst'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Amethyst'), scale_colour_stevenUniverse(palette = 'Amethyst'))
 })
 
 test_that('scale_colour_Amethyst works', {
@@ -67,7 +74,7 @@ test_that('Pearl_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Pearl', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Pearl'), scale_colour_stevenUniverse(palette = 'Pearl'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Pearl'), scale_colour_stevenUniverse(palette = 'Pearl'))
 })
 
 test_that('scale_colour_Pearl works', {
@@ -87,7 +94,7 @@ test_that('RoseQuartz_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_RoseQuartz', {
-  expect_equal(scale_color_stevenUniverse(palette = 'RoseQuartz'), scale_colour_stevenUniverse(palette = 'RoseQuartz'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'RoseQuartz'), scale_colour_stevenUniverse(palette = 'RoseQuartz'))
 })
 
 test_that('scale_colour_RoseQuartz works', {
@@ -107,7 +114,7 @@ test_that('Peridot_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Peridot', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Peridot'), scale_colour_stevenUniverse(palette = 'Peridot'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Peridot'), scale_colour_stevenUniverse(palette = 'Peridot'))
 })
 
 test_that('scale_colour_Peridot works', {
@@ -127,7 +134,7 @@ test_that('LapisLazuli_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_LapisLazuli', {
-  expect_equal(scale_color_stevenUniverse(palette = 'LapisLazuli'), scale_colour_stevenUniverse(palette = 'LapisLazuli'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'LapisLazuli'), scale_colour_stevenUniverse(palette = 'LapisLazuli'))
 })
 
 test_that('scale_colour_LapisLazuli works', {
@@ -147,7 +154,7 @@ test_that('Diamonds_pal raises warning with large number, x > 9', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Diamonds', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Diamonds'), scale_colour_stevenUniverse(palette = 'Diamonds'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Diamonds'), scale_colour_stevenUniverse(palette = 'Diamonds'))
 })
 
 test_that('scale_colour_Diamonds works', {
@@ -167,7 +174,7 @@ test_that('Jasper_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Jasper', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Jasper'), scale_colour_stevenUniverse(palette = 'Jasper'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Jasper'), scale_colour_stevenUniverse(palette = 'Jasper'))
 })
 
 test_that('scale_colour_Jasper works', {
@@ -187,7 +194,7 @@ test_that('Topaz_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Topaz', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Topaz'), scale_colour_stevenUniverse(palette = 'Topaz'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Topaz'), scale_colour_stevenUniverse(palette = 'Topaz'))
 })
 
 test_that('scale_colour_Topaz works', {
@@ -207,7 +214,7 @@ test_that('Spinel_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Spinel', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Spinel'), scale_colour_stevenUniverse(palette = 'Spinel'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Spinel'), scale_colour_stevenUniverse(palette = 'Spinel'))
 })
 
 test_that('scale_colour_Spinel works', {
@@ -227,7 +234,7 @@ test_that('Bismuth_pal raises warning with large number, x > 8', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Bismuth', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Bismuth'), scale_colour_stevenUniverse(palette = 'Bismuth'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Bismuth'), scale_colour_stevenUniverse(palette = 'Bismuth'))
 })
 
 test_that('scale_colour_Bismuth works', {
@@ -247,7 +254,7 @@ test_that('Ruby_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Ruby', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Ruby'), scale_colour_stevenUniverse(palette = 'Ruby'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Ruby'), scale_colour_stevenUniverse(palette = 'Ruby'))
 })
 
 test_that('scale_colour_Ruby works', {
@@ -267,7 +274,7 @@ test_that('Sapphire_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Sapphire', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Sapphire'), scale_colour_stevenUniverse(palette = 'Sapphire'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Sapphire'), scale_colour_stevenUniverse(palette = 'Sapphire'))
 })
 
 test_that('scale_colour_Sapphire works', {
@@ -287,7 +294,7 @@ test_that('Emerald_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Emerald', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Emerald'), scale_colour_stevenUniverse(palette = 'Emerald'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Emerald'), scale_colour_stevenUniverse(palette = 'Emerald'))
 })
 
 test_that('scale_colour_Emerald works', {
@@ -307,7 +314,7 @@ test_that('Nephrite_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Nephrite', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Nephrite'), scale_colour_stevenUniverse(palette = 'Nephrite'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Nephrite'), scale_colour_stevenUniverse(palette = 'Nephrite'))
 })
 
 test_that('scale_colour_Nephrite works', {
@@ -327,7 +334,7 @@ test_that('Aquamarine_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Aquamarine', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Aquamarine'), scale_colour_stevenUniverse(palette = 'Aquamarine'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Aquamarine'), scale_colour_stevenUniverse(palette = 'Aquamarine'))
 })
 
 test_that('scale_colour_Aquamarine works', {
@@ -347,7 +354,7 @@ test_that('Padparadscha_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Padparadscha', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Padparadscha'), scale_colour_stevenUniverse(palette = 'Padparadscha'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Padparadscha'), scale_colour_stevenUniverse(palette = 'Padparadscha'))
 })
 
 test_that('scale_colour_Padparadscha works', {
@@ -367,7 +374,7 @@ test_that('Rutile_pal raises warning with large number, x > 5', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Rutile', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Rutile'), scale_colour_stevenUniverse(palette = 'Rutile'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Rutile'), scale_colour_stevenUniverse(palette = 'Rutile'))
 })
 
 test_that('scale_colour_Rutile works', {
@@ -387,7 +394,7 @@ test_that('Rhodonite_pal raises warning with large number, x > 8', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Rhodonite', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Rhodonite'), scale_colour_stevenUniverse(palette = 'Rhodonite'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Rhodonite'), scale_colour_stevenUniverse(palette = 'Rhodonite'))
 })
 
 test_that('scale_colour_Rhodonite works', {
@@ -407,7 +414,7 @@ test_that('Flourite_pal raises warning with large number, x > 8', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Flourite', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Flourite'), scale_colour_stevenUniverse(palette = 'Flourite'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Flourite'), scale_colour_stevenUniverse(palette = 'Flourite'))
 })
 
 test_that('scale_colour_Flourite works', {
@@ -427,7 +434,7 @@ test_that('MegaPearl_pal raises warning with large number, x > 9', {
 })
 
 test_that('scale_colour_Steven equals scale_color_MegaPearl', {
-  expect_equal(scale_color_stevenUniverse(palette = 'MegaPearl'), scale_colour_stevenUniverse(palette = 'MegaPearl'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'MegaPearl'), scale_colour_stevenUniverse(palette = 'MegaPearl'))
 })
 
 test_that('scale_colour_MegaPearl works', {
@@ -447,7 +454,7 @@ test_that('Sugilite_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Sugilite', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Sugilite'), scale_colour_stevenUniverse(palette = 'Sugilite'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Sugilite'), scale_colour_stevenUniverse(palette = 'Sugilite'))
 })
 
 test_that('scale_colour_Sugilite works', {
@@ -467,7 +474,7 @@ test_that('CrazyLaceAgate_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_CrazyLaceAgate', {
-  expect_equal(scale_color_stevenUniverse(palette = 'CrazyLaceAgate'), scale_colour_stevenUniverse(palette = 'CrazyLaceAgate'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'CrazyLaceAgate'), scale_colour_stevenUniverse(palette = 'CrazyLaceAgate'))
 })
 
 test_that('scale_colour_CrazyLaceAgate works', {
@@ -487,7 +494,7 @@ test_that('Sardonyx_pal raises warning with large number, x > 8', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Sardonyx', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Sardonyx'), scale_colour_stevenUniverse(palette = 'Sardonyx'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Sardonyx'), scale_colour_stevenUniverse(palette = 'Sardonyx'))
 })
 
 test_that('scale_colour_Sardonyx works', {
@@ -507,7 +514,7 @@ test_that('Alexandrite_pal raises warning with large number, x > 8', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Alexandrite', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Alexandrite'), scale_colour_stevenUniverse(palette = 'Alexandrite'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Alexandrite'), scale_colour_stevenUniverse(palette = 'Alexandrite'))
 })
 
 test_that('scale_colour_Alexandrite works', {
@@ -527,7 +534,7 @@ test_that('SmokyQuartz_pal raises warning with large number, x > 6', {
 })
 
 test_that('scale_colour_Steven equals scale_color_SmokyQuartz', {
-  expect_equal(scale_color_stevenUniverse(palette = 'SmokyQuartz'), scale_colour_stevenUniverse(palette = 'SmokyQuartz'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'SmokyQuartz'), scale_colour_stevenUniverse(palette = 'SmokyQuartz'))
 })
 
 test_that('scale_colour_SmokyQuartz works', {
@@ -547,7 +554,7 @@ test_that('BluebirdAzurite_pal raises warning with large number, x > 5', {
 })
 
 test_that('scale_colour_Steven equals scale_color_BluebirdAzurite', {
-  expect_equal(scale_color_stevenUniverse(palette = 'BluebirdAzurite'), scale_colour_stevenUniverse(palette = 'BluebirdAzurite'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'BluebirdAzurite'), scale_colour_stevenUniverse(palette = 'BluebirdAzurite'))
 })
 
 test_that('scale_colour_BluebirdAzurite works', {
@@ -567,7 +574,7 @@ test_that('Sunstone_pal raises warning with large number, x > 9', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Sunstone', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Sunstone'), scale_colour_stevenUniverse(palette = 'Sunstone'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Sunstone'), scale_colour_stevenUniverse(palette = 'Sunstone'))
 })
 
 test_that('scale_colour_Sunstone works', {
@@ -587,7 +594,7 @@ test_that('Opal_pal raises warning with large number, x > 7', {
 })
 
 test_that('scale_colour_Steven equals scale_color_Opal', {
-  expect_equal(scale_color_stevenUniverse(palette = 'Opal'), scale_colour_stevenUniverse(palette = 'Opal'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'Opal'), scale_colour_stevenUniverse(palette = 'Opal'))
 })
 
 test_that('scale_colour_Opal works', {
@@ -607,7 +614,7 @@ test_that('CrystalGems_pal raises warning with large number, x > 12', {
 })
 
 test_that('scale_colour_Steven equals scale_color_CrystalGems', {
-  expect_equal(scale_color_stevenUniverse(palette = 'CrystalGems'), scale_colour_stevenUniverse(palette = 'CrystalGems'))
+  expect_equal_scales(scale_color_stevenUniverse(palette = 'CrystalGems'), scale_colour_stevenUniverse(palette = 'CrystalGems'))
 })
 
 test_that('scale_colour_CrystalGems works', {

--- a/tests/testthat/test-thelastairbender.R
+++ b/tests/testthat/test-thelastairbender.R
@@ -1,6 +1,12 @@
 context("test-thelastairbender")
 
 expect_eqNe <- function(...) expect_equal(..., check.environment=FALSE)
+expect_equal_scales <- function(x, y, ...) {
+  x <- as.list(x)
+  y <- as.list(y)
+  x$call <- y$call <- NULL
+  expect_equal(x, y, ...)
+}
 
 test_that("theme_avatar works", {
   thm <- theme_avatar()
@@ -73,7 +79,7 @@ test_that("WaterTribe_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_WaterTribe equals scale_color_WaterTribe", {
-  expect_eqNe(scale_color_avatar(palette = "WaterTribe"), scale_colour_avatar(palette = "WaterTribe"))
+  expect_equal_scales(scale_color_avatar(palette = "WaterTribe"), scale_colour_avatar(palette = "WaterTribe"))
 })
 
 test_that("scale_colour_WaterTribe works", {
@@ -92,7 +98,7 @@ test_that("EarthKingdom_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_EarthKingdom equals scale_color_EarthKingdom", {
-  expect_eqNe(scale_color_avatar(palette = "EarthKingdom"), scale_colour_avatar(palette = "EarthKingdom"))
+  expect_equal_scales(scale_color_avatar(palette = "EarthKingdom"), scale_colour_avatar(palette = "EarthKingdom"))
 })
 
 test_that("scale_colour_EarthKingdom works", {
@@ -109,7 +115,7 @@ test_that("AirNomads_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_AirNomads equals scale_color_AirNomads", {
-  expect_eqNe(scale_color_avatar(palette = "AirNomads"), scale_colour_avatar(palette = "AirNomads"))
+  expect_equal_scales(scale_color_avatar(palette = "AirNomads"), scale_colour_avatar(palette = "AirNomads"))
 })
 
 test_that("scale_colour_AirNomads works", {
@@ -200,7 +206,7 @@ test_that("fireNation_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_fireNation equals scale_color_fireNation", {
-  expect_eqNe(scale_color_avatar(palette = "FireNation"), scale_colour_avatar(palette = "FireNation"))
+  expect_equal_scales(scale_color_avatar(palette = "FireNation"), scale_colour_avatar(palette = "FireNation"))
 })
 
 test_that("scale_colour_fireNation works", {
@@ -217,7 +223,7 @@ test_that("WaterTribe_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_WaterTribe equals scale_color_WaterTribe", {
-  expect_eqNe(scale_color_avatar(palette = "WaterTribe"), scale_colour_avatar(palette = "WaterTribe"))
+  expect_equal_scales(scale_color_avatar(palette = "WaterTribe"), scale_colour_avatar(palette = "WaterTribe"))
 })
 
 test_that("scale_colour_WaterTribe works", {
@@ -234,7 +240,7 @@ test_that("EarthKingdom_pal raises warning with large number, x > 9", {
 })
 
 test_that("scale_colour_EarthKingdom equals scale_color_EarthKingdom", {
-  expect_eqNe(scale_color_avatar(palette = "EarthKingdom"), scale_colour_avatar(palette = "EarthKingdom"))
+  expect_equal_scales(scale_color_avatar(palette = "EarthKingdom"), scale_colour_avatar(palette = "EarthKingdom"))
 })
 
 test_that("scale_colour_EarthKingdom works", {
@@ -251,7 +257,7 @@ test_that("AirNomads_pal raises warning with large number, x > 8", {
 })
 
 test_that("scale_colour_AirNomads equals scale_color_AirNomads", {
-  expect_eqNe(scale_color_avatar(palette = "AirNomads"), scale_colour_avatar(palette = "AirNomads"))
+  expect_equal_scales(scale_color_avatar(palette = "AirNomads"), scale_colour_avatar(palette = "AirNomads"))
 })
 
 test_that("scale_colour_AirNomads works", {


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break tvthemes.

We changed the internals of scales a bit to provide more accurate error messages. Unfortunately, this makes testing for the equality of scales a bit more difficult. This PR updates the tests to ignore the `call` field of scales. In addition, a few tests for the `scale_name` field were deleted, as this field is to become deprecated in the new ggplot2 version.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help tvthemes get out a fix if necessary.